### PR TITLE
Install CMake config files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,6 +24,9 @@ if(NOT NO_GUI)
     find_package(Qt5Widgets)
 endif()
 
+# cmake macros used
+include(GNUInstallDirs)
+
 # Include Directories.
 include_directories(.)
 include_directories(include)
@@ -95,13 +98,13 @@ configure_file(
 
 install(FILES
   ${CMAKE_BINARY_DIR}/AppImageUpdaterBridge.pc
-  DESTINATION "lib/pkgconfig")
+  DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig")
 
 install(FILES
   ${CMAKE_BINARY_DIR}/libAppImageUpdaterBridge.a
-  DESTINATION "lib/")
+  DESTINATION "${CMAKE_INSTALL_LIBDIR}")
 
 install(FILES
   ${toinstall}
-  DESTINATION "include/AppImageUpdaterBridge/")
+  DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/AppImageUpdaterBridge")
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,15 +17,18 @@ set(CMAKE_CXX_FLAGS "-Wall -Wextra")
 set(CMAKE_CXX_FLAGS_DEBUG "-g")
 set(CMAKE_CXX_FLAGS_RELEASE "-O3")
 
-find_package(Qt5Core)
-find_package(Qt5Network)
+set(MIN_QT_VERSION "5.6.0")
+
+find_package(Qt5Core ${MIN_QT_VERSION})
+find_package(Qt5Network ${MIN_QT_VERSION})
 
 if(NOT NO_GUI)
-    find_package(Qt5Widgets)
+    find_package(Qt5Widgets ${MIN_QT_VERSION})
 endif()
 
 # cmake macros used
 include(GNUInstallDirs)
+include(CMakePackageConfigHelpers)
 
 # Include Directories.
 include_directories(.)
@@ -82,7 +85,8 @@ endif()
 add_library(AppImageUpdaterBridge ${source})
 target_compile_definitions(AppImageUpdaterBridge PUBLIC LOGGING_DISABLED=LG)
 target_link_libraries(AppImageUpdaterBridge PUBLIC Qt5::Core Qt5::Network)
-target_include_directories(AppImageUpdaterBridge PUBLIC . include)
+target_include_directories(AppImageUpdaterBridge INTERFACE "$<BUILD_INTERFACE:. include>")
+target_include_directories(AppImageUpdaterBridge INTERFACE "$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/AppImageUpdaterBridge>" )
 
 if(NOT NO_GUI)
     target_link_libraries(AppImageUpdaterBridge PUBLIC Qt5::Widgets)
@@ -100,11 +104,30 @@ install(FILES
   ${CMAKE_BINARY_DIR}/AppImageUpdaterBridge.pc
   DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig")
 
-install(FILES
-  ${CMAKE_BINARY_DIR}/libAppImageUpdaterBridge.a
+install(TARGETS
+  AppImageUpdaterBridge
+  EXPORT AppImageUpdaterBridgeTargets
   DESTINATION "${CMAKE_INSTALL_LIBDIR}")
 
 install(FILES
   ${toinstall}
   DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/AppImageUpdaterBridge")
 
+# Add CMake config
+set(CMAKECONFIG_INSTALL_DIR "${CMAKE_INSTALL_LIBDIR}/cmake/AppImageUpdaterBridge")
+if(NOT NO_GUI)
+    set(PACKAGE_FIND_DEPENDENCY_QTWIDGETS "find_dependency(Qt5Widgets ${MIN_QT_VERSION})")
+endif()
+configure_package_config_file(
+  "${CMAKE_SOURCE_DIR}/other/cmake/AppImageUpdaterBridgeConfig.cmake.in"
+  "${CMAKE_CURRENT_BINARY_DIR}/AppImageUpdaterBridgeConfig.cmake"
+  INSTALL_DESTINATION  ${CMAKECONFIG_INSTALL_DIR}
+)
+
+install(FILES
+  "${CMAKE_CURRENT_BINARY_DIR}/AppImageUpdaterBridgeConfig.cmake"
+  DESTINATION "${CMAKECONFIG_INSTALL_DIR}")
+
+install(EXPORT AppImageUpdaterBridgeTargets
+  FILE AppImageUpdaterBridgeTargets.cmake
+  DESTINATION "${CMAKECONFIG_INSTALL_DIR}")

--- a/examples/ProxyUpdate/CMakeLists.txt
+++ b/examples/ProxyUpdate/CMakeLists.txt
@@ -1,0 +1,12 @@
+cmake_minimum_required(VERSION 3.2)
+
+project(ProxyUpdate)
+
+set(CMAKE_INCLUDE_CURRENT_DIR ON)
+
+# find installed library
+find_package(AppImageUpdaterBridge)
+
+add_executable(ProxyUpdate main.cc)
+
+target_link_libraries(ProxyUpdate PRIVATE AppImageUpdaterBridge)

--- a/examples/SimpleUpdate/CMakeLists.txt
+++ b/examples/SimpleUpdate/CMakeLists.txt
@@ -1,0 +1,12 @@
+cmake_minimum_required(VERSION 3.2)
+
+project(SimpleUpdate)
+
+set(CMAKE_INCLUDE_CURRENT_DIR ON)
+
+# find installed library
+find_package(AppImageUpdaterBridge)
+
+add_executable(SimpleUpdate main.cc TextProgressBar.cc)
+
+target_link_libraries(SimpleUpdate PRIVATE AppImageUpdaterBridge)

--- a/examples/SimpleUpdateGUI/CMakeLists.txt
+++ b/examples/SimpleUpdateGUI/CMakeLists.txt
@@ -1,0 +1,12 @@
+cmake_minimum_required(VERSION 3.2)
+
+project(SimpleUpdateGUI)
+
+set(CMAKE_INCLUDE_CURRENT_DIR ON)
+
+# find installed library
+find_package(AppImageUpdaterBridge)
+
+add_executable(SimpleUpdateGUI main.cc)
+
+target_link_libraries(SimpleUpdateGUI PRIVATE AppImageUpdaterBridge)

--- a/other/cmake/AppImageUpdaterBridgeConfig.cmake.in
+++ b/other/cmake/AppImageUpdaterBridgeConfig.cmake.in
@@ -1,0 +1,8 @@
+@PACKAGE_INIT@
+
+include(CMakeFindDependencyMacro)
+find_dependency(Qt5Core @MIN_QT_VERSION@)
+find_dependency(Qt5Network @MIN_QT_VERSION@)
+@PACKAGE_FIND_DEPENDENCY_QTWIDGETS@
+
+include("${CMAKE_CURRENT_LIST_DIR}/AppImageUpdaterBridgeTargets.cmake")

--- a/other/pkgconfig/AppImageUpdaterBridge.pc.in
+++ b/other/pkgconfig/AppImageUpdaterBridge.pc.in
@@ -1,6 +1,6 @@
 prefix=@CMAKE_INSTALL_PREFIX@
-libdir=${prefix}/lib
-includedir=${prefix}/include/AppImageUpdaterBridge
+libdir=${prefix}/@CMAKE_INSTALL_LIBDIR@
+includedir=${prefix}/@CMAKE_INSTALL_INCLUDEDIR@/AppImageUpdaterBridge
 
 Name: AppImageUpdaterBridge
 Description: A Qt5 library for delta updating the AppImage format


### PR DESCRIPTION
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this pull request introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [x] Build-related changes
- [ ] Other, please describe:

**Describe your Pull Request:**
Not every system uses e.g. "lib/" as directory for libraries (could be also /lib64 or the Debian variant). CMake's default GNUInstallDirs macros helps here with that.
Then, other projects using CMake and wanting to use this library might find it fancy to have CMake config files deployed for this library, so a simple `find_package(AppImageUpdaterBridge)` gets them ready to build and link against this lib, by just using the imported target `AppImageUpdaterBridge`.

Patches done after hint for need by @azubieta last Friday on irc channel `#appimage` (me being "frinring"), to prepare the building by packagers of Linux distributions of this and dependent software.